### PR TITLE
Wrap builder script with `jq` and `curl`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,9 @@
   }: {
     packages =
       nixpkgs.lib.mapAttrs (system: pkgs: {
-        buildScript = pkgs.runCommand "start-docker-nix-build-slave" {} ''
-          cp ${./start-docker-nix-build-slave} $out
+        builderScript = pkgs.writeShellScript "start-docker-nix-build-slave" ''
+          PATH=$PATH:${nixpkgs.lib.makeBinPath (with pkgs; [jq curl])}
+          source ${./start-docker-nix-build-slave}
         '';
       })
       nixpkgs.legacyPackages;


### PR DESCRIPTION
During testing on a Mac, it failed as it was missing `jq`, I think `curl` is the other thing we use that may be missing, so I added that to the wrapper too. Yes, sourcing in the sourced bash script works, the check to ensure it is being sourced _probably_ doesn't but we can fix that if it's important.